### PR TITLE
fix short circuiting logic when doing exact matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# Unreleased
+
+## Bugfixes
+
+* when the needle is composed of a single char, return the score and index
+  of the best position instead of always returning the first matched character
+  in the haystack
+
 # [0.2.1] - 2023-09-02
 
 ## Bugfixes

--- a/matcher/src/exact.rs
+++ b/matcher/src/exact.rs
@@ -27,7 +27,7 @@ impl Matcher {
                     max_pos = i as u32;
                     max_score = score;
                     // can't get better than this
-                    if score >= self.config.bonus_boundary_white {
+                    if bonus >= self.config.bonus_boundary_white {
                         break;
                     }
                 }
@@ -45,7 +45,7 @@ impl Matcher {
                     max_pos = i as u32;
                     max_score = score;
                     // can't get better than this
-                    if score >= self.config.bonus_boundary_white {
+                    if bonus >= self.config.bonus_boundary_white {
                         break;
                     }
                 }
@@ -88,7 +88,7 @@ impl Matcher {
                 max_pos = i;
                 max_score = score;
                 // can't get better than this
-                if score >= self.config.bonus_boundary_white {
+                if bonus >= self.config.bonus_boundary_white {
                     break;
                 }
             }
@@ -163,7 +163,7 @@ impl Matcher {
                     max_pos = i;
                     max_score = score;
                     // can't get better than this
-                    if score >= self.config.bonus_boundary_white {
+                    if bonus >= self.config.bonus_boundary_white {
                         break;
                     }
                 }
@@ -207,7 +207,7 @@ impl Matcher {
                 max_pos = i as u32;
                 max_score = score;
                 // can't get better than this
-                if score >= self.config.bonus_boundary_white {
+                if bonus >= self.config.bonus_boundary_white {
                     break;
                 }
             }
@@ -253,7 +253,7 @@ impl Matcher {
                 max_pos = i;
                 max_score = score;
                 // can't get better than this
-                if score >= self.config.bonus_boundary_white {
+                if bonus >= self.config.bonus_boundary_white {
                     break;
                 }
             }

--- a/matcher/src/tests.rs
+++ b/matcher/src/tests.rs
@@ -668,3 +668,33 @@ fn test_prefer_prefix() {
         ],
     );
 }
+
+#[test]
+fn test_single_char_needle() {
+    assert_matches(
+        &[FuzzyOptimal],
+        false,
+        false,
+        false,
+        false,
+        &[(
+            "foO",
+            "o",
+            &[2],
+            BONUS_FIRST_CHAR_MULTIPLIER * BONUS_CAMEL123,
+        )],
+    );
+    assert_matches(
+        &[FuzzyOptimal],
+        false,
+        false,
+        false,
+        false,
+        &[(
+            "föÖ",
+            "ö",
+            &[2],
+            BONUS_FIRST_CHAR_MULTIPLIER * BONUS_CAMEL123,
+        )],
+    );
+}


### PR DESCRIPTION
I noticed you stop looking for matches as soon as `score >= self.config.bonus_boundary_white`. I believe this is a typo since `score` is always `>= 16` and `bonus_boundary_white` is always `<= 10`, which means you always return the score (and position) of the first match.

This is done in a bunch of place in the `exact` module. I've only fixed the first one because I wanted to get some feedback before fixing the others. If it LGTY I can go ahead.