### PR TITLE
Correctly handle normalization in pattern API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bugfixes
 
+* avoid incorrect matches when searching for ASCII needles in a Unicode haystack
 * correctly handle Unicode normalization when there are normalizable characters in the pattern, for example characters with umlauts
 * when the needle is composed of a single char, return the score and index
   of the best position instead of always returning the first matched character

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-# Unreleased
+# [0.3.0] - 2023-12-20
+
+## **Breaking Changes**
+
+* Pattern API method now requires a Unicode `Normalization` strategy in addition to a `CaseMatching` strategy.
 
 ## Bugfixes
 
+* correctly handle Unicode normalization when there are normalizable characters in the pattern, for example characters with umlauts
 * when the needle is composed of a single char, return the score and index
   of the best position instead of always returning the first matched character
   in the haystack
@@ -19,5 +24,6 @@
 *initial public release*
 
 
+[0.3.0]: https://github.com/helix-editor/nucleo/releases/tag/nucleo-v0.3.0
 [0.2.1]: https://github.com/helix-editor/nucleo/releases/tag/nucleo-v0.2.1
 [0.2.0]: https://github.com/helix-editor/nucleo/releases/tag/nucleo-v0.2.0

--- a/matcher/src/exact.rs
+++ b/matcher/src/exact.rs
@@ -258,6 +258,9 @@ impl Matcher {
                 }
             }
         }
+        if max_score == 0 {
+            return None;
+        }
 
         let score = self.calculate_score::<INDICES, _, _>(
             haystack,

--- a/matcher/src/lib.rs
+++ b/matcher/src/lib.rs
@@ -496,15 +496,8 @@ impl Matcher {
                         .substring_match_1_non_ascii::<INDICES>(haystack, needle, start, indices);
                     return Some(res);
                 }
-                let (start, end) = self.prefilter_non_ascii(haystack, needle_, false)?;
-                self.fuzzy_match_optimal::<INDICES, char, char>(
-                    haystack,
-                    needle,
-                    start,
-                    start + 1,
-                    end,
-                    indices,
-                )
+                let (start, _) = self.prefilter_non_ascii(haystack, needle_, false)?;
+                self.substring_match_non_ascii::<INDICES, _>(haystack, needle, start, indices)
             }
         }
     }

--- a/matcher/src/lib.rs
+++ b/matcher/src/lib.rs
@@ -16,12 +16,12 @@ can contain special characters to control what kind of match is performed (see
 
 ```
 # use nucleo_matcher::{Matcher, Config};
-# use nucleo_matcher::pattern::{Pattern, CaseMatching};
+# use nucleo_matcher::pattern::{Pattern, Normalization, CaseMatching};
 let paths = ["foo/bar", "bar/foo", "foobar"];
 let mut matcher = Matcher::new(Config::DEFAULT.match_paths());
-let matches = Pattern::parse("foo bar", CaseMatching::Ignore).match_list(paths, &mut matcher);
+let matches = Pattern::parse("foo bar", CaseMatching::Ignore, Normalization::Smart).match_list(paths, &mut matcher);
 assert_eq!(matches, vec![("foo/bar", 168), ("bar/foo", 168), ("foobar", 140)]);
-let matches = Pattern::parse("^foo bar", CaseMatching::Ignore).match_list(paths, &mut matcher);
+let matches = Pattern::parse("^foo bar", CaseMatching::Ignore, Normalization::Smart).match_list(paths, &mut matcher);
 assert_eq!(matches, vec![("foo/bar", 168), ("foobar", 140)]);
 ```
 
@@ -30,13 +30,13 @@ If the pattern should be matched literally (without this special parsing)
 
 ```
 # use nucleo_matcher::{Matcher, Config};
-# use nucleo_matcher::pattern::{Pattern, CaseMatching, AtomKind};
+# use nucleo_matcher::pattern::{Pattern, CaseMatching, AtomKind, Normalization};
 let paths = ["foo/bar", "bar/foo", "foobar"];
 let mut matcher = Matcher::new(Config::DEFAULT.match_paths());
-let matches = Pattern::new("foo bar", CaseMatching::Ignore, AtomKind::Fuzzy).match_list(paths, &mut matcher);
+let matches = Pattern::new("foo bar", CaseMatching::Ignore, Normalization::Smart, AtomKind::Fuzzy).match_list(paths, &mut matcher);
 assert_eq!(matches, vec![("foo/bar", 168), ("bar/foo", 168), ("foobar", 140)]);
 let paths = ["^foo/bar", "bar/^foo", "foobar"];
-let matches = Pattern::new("^foo bar", CaseMatching::Ignore, AtomKind::Fuzzy).match_list(paths, &mut matcher);
+let matches = Pattern::new("^foo bar", CaseMatching::Ignore, Normalization::Smart, AtomKind::Fuzzy).match_list(paths, &mut matcher);
 assert_eq!(matches, vec![("^foo/bar", 188), ("bar/^foo", 188)]);
 ```
 
@@ -44,10 +44,10 @@ If word segmentation is also not desired, a single `Atom` can be constructed dir
 
 ```
 # use nucleo_matcher::{Matcher, Config};
-# use nucleo_matcher::pattern::{Pattern, Atom, CaseMatching, AtomKind};
+# use nucleo_matcher::pattern::{Pattern, Atom, CaseMatching, Normalization, AtomKind};
 let paths = ["foobar", "foo bar"];
 let mut matcher = Matcher::new(Config::DEFAULT);
-let matches = Atom::new("foo bar", CaseMatching::Ignore, AtomKind::Fuzzy, false).match_list(paths, &mut matcher);
+let matches = Atom::new("foo bar", CaseMatching::Ignore, Normalization::Smart, AtomKind::Fuzzy, false).match_list(paths, &mut matcher);
 assert_eq!(matches, vec![("foo bar", 192)]);
 ```
 

--- a/matcher/src/pattern/tests.rs
+++ b/matcher/src/pattern/tests.rs
@@ -1,20 +1,20 @@
-use crate::pattern::{Atom, AtomKind, CaseMatching};
+use crate::pattern::{Atom, AtomKind, CaseMatching, Normalization};
 
 #[test]
 fn negative() {
-    let pat = Atom::parse("!foo", CaseMatching::Smart);
+    let pat = Atom::parse("!foo", CaseMatching::Smart, Normalization::Smart);
     assert!(pat.negative);
     assert_eq!(pat.kind, AtomKind::Substring);
     assert_eq!(pat.needle.to_string(), "foo");
-    let pat = Atom::parse("!^foo", CaseMatching::Smart);
+    let pat = Atom::parse("!^foo", CaseMatching::Smart, Normalization::Smart);
     assert!(pat.negative);
     assert_eq!(pat.kind, AtomKind::Prefix);
     assert_eq!(pat.needle.to_string(), "foo");
-    let pat = Atom::parse("!foo$", CaseMatching::Smart);
+    let pat = Atom::parse("!foo$", CaseMatching::Smart, Normalization::Smart);
     assert!(pat.negative);
     assert_eq!(pat.kind, AtomKind::Postfix);
     assert_eq!(pat.needle.to_string(), "foo");
-    let pat = Atom::parse("!^foo$", CaseMatching::Smart);
+    let pat = Atom::parse("!^foo$", CaseMatching::Smart, Normalization::Smart);
     assert!(pat.negative);
     assert_eq!(pat.kind, AtomKind::Exact);
     assert_eq!(pat.needle.to_string(), "foo");
@@ -22,23 +22,23 @@ fn negative() {
 
 #[test]
 fn pattern_kinds() {
-    let pat = Atom::parse("foo", CaseMatching::Smart);
+    let pat = Atom::parse("foo", CaseMatching::Smart, Normalization::Smart);
     assert!(!pat.negative);
     assert_eq!(pat.kind, AtomKind::Fuzzy);
     assert_eq!(pat.needle.to_string(), "foo");
-    let pat = Atom::parse("'foo", CaseMatching::Smart);
+    let pat = Atom::parse("'foo", CaseMatching::Smart, Normalization::Smart);
     assert!(!pat.negative);
     assert_eq!(pat.kind, AtomKind::Substring);
     assert_eq!(pat.needle.to_string(), "foo");
-    let pat = Atom::parse("^foo", CaseMatching::Smart);
+    let pat = Atom::parse("^foo", CaseMatching::Smart, Normalization::Smart);
     assert!(!pat.negative);
     assert_eq!(pat.kind, AtomKind::Prefix);
     assert_eq!(pat.needle.to_string(), "foo");
-    let pat = Atom::parse("foo$", CaseMatching::Smart);
+    let pat = Atom::parse("foo$", CaseMatching::Smart, Normalization::Smart);
     assert!(!pat.negative);
     assert_eq!(pat.kind, AtomKind::Postfix);
     assert_eq!(pat.needle.to_string(), "foo");
-    let pat = Atom::parse("^foo$", CaseMatching::Smart);
+    let pat = Atom::parse("^foo$", CaseMatching::Smart, Normalization::Smart);
     assert!(!pat.negative);
     assert_eq!(pat.kind, AtomKind::Exact);
     assert_eq!(pat.needle.to_string(), "foo");
@@ -46,69 +46,69 @@ fn pattern_kinds() {
 
 #[test]
 fn case_matching() {
-    let pat = Atom::parse("foo", CaseMatching::Smart);
+    let pat = Atom::parse("foo", CaseMatching::Smart, Normalization::Smart);
     assert!(pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "foo");
-    let pat = Atom::parse("Foo", CaseMatching::Smart);
+    let pat = Atom::parse("Foo", CaseMatching::Smart, Normalization::Smart);
     assert!(!pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "Foo");
-    let pat = Atom::parse("Foo", CaseMatching::Ignore);
+    let pat = Atom::parse("Foo", CaseMatching::Ignore, Normalization::Smart);
     assert!(pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "foo");
-    let pat = Atom::parse("Foo", CaseMatching::Respect);
+    let pat = Atom::parse("Foo", CaseMatching::Respect, Normalization::Smart);
     assert!(!pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "Foo");
-    let pat = Atom::parse("Foo", CaseMatching::Respect);
+    let pat = Atom::parse("Foo", CaseMatching::Respect, Normalization::Smart);
     assert!(!pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "Foo");
-    let pat = Atom::parse("Äxx", CaseMatching::Ignore);
+    let pat = Atom::parse("Äxx", CaseMatching::Ignore, Normalization::Smart);
     assert!(pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "äxx");
-    let pat = Atom::parse("Äxx", CaseMatching::Respect);
+    let pat = Atom::parse("Äxx", CaseMatching::Respect, Normalization::Smart);
     assert!(!pat.ignore_case);
-    let pat = Atom::parse("Axx", CaseMatching::Smart);
+    let pat = Atom::parse("Axx", CaseMatching::Smart, Normalization::Smart);
     assert!(!pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "Axx");
-    let pat = Atom::parse("你xx", CaseMatching::Smart);
+    let pat = Atom::parse("你xx", CaseMatching::Smart, Normalization::Smart);
     assert!(pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "你xx");
-    let pat = Atom::parse("你xx", CaseMatching::Ignore);
+    let pat = Atom::parse("你xx", CaseMatching::Ignore, Normalization::Smart);
     assert!(pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "你xx");
-    let pat = Atom::parse("Ⲽxx", CaseMatching::Smart);
+    let pat = Atom::parse("Ⲽxx", CaseMatching::Smart, Normalization::Smart);
     assert!(!pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "Ⲽxx");
-    let pat = Atom::parse("Ⲽxx", CaseMatching::Ignore);
+    let pat = Atom::parse("Ⲽxx", CaseMatching::Ignore, Normalization::Smart);
     assert!(pat.ignore_case);
     assert_eq!(pat.needle.to_string(), "ⲽxx");
 }
 
 #[test]
 fn escape() {
-    let pat = Atom::parse("foo\\ bar", CaseMatching::Smart);
+    let pat = Atom::parse("foo\\ bar", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "foo bar");
-    let pat = Atom::parse("\\!foo", CaseMatching::Smart);
+    let pat = Atom::parse("\\!foo", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "!foo");
     assert_eq!(pat.kind, AtomKind::Fuzzy);
-    let pat = Atom::parse("\\'foo", CaseMatching::Smart);
+    let pat = Atom::parse("\\'foo", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "'foo");
     assert_eq!(pat.kind, AtomKind::Fuzzy);
-    let pat = Atom::parse("\\^foo", CaseMatching::Smart);
+    let pat = Atom::parse("\\^foo", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "^foo");
     assert_eq!(pat.kind, AtomKind::Fuzzy);
-    let pat = Atom::parse("foo\\$", CaseMatching::Smart);
+    let pat = Atom::parse("foo\\$", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "foo$");
     assert_eq!(pat.kind, AtomKind::Fuzzy);
-    let pat = Atom::parse("^foo\\$", CaseMatching::Smart);
+    let pat = Atom::parse("^foo\\$", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "foo$");
     assert_eq!(pat.kind, AtomKind::Prefix);
-    let pat = Atom::parse("\\^foo\\$", CaseMatching::Smart);
+    let pat = Atom::parse("\\^foo\\$", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "^foo$");
     assert_eq!(pat.kind, AtomKind::Fuzzy);
-    let pat = Atom::parse("\\!^foo\\$", CaseMatching::Smart);
+    let pat = Atom::parse("\\!^foo\\$", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "!^foo$");
     assert_eq!(pat.kind, AtomKind::Fuzzy);
-    let pat = Atom::parse("!\\^foo\\$", CaseMatching::Smart);
+    let pat = Atom::parse("!\\^foo\\$", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "^foo$");
     assert_eq!(pat.kind, AtomKind::Substring);
 }

--- a/matcher/src/tests.rs
+++ b/matcher/src/tests.rs
@@ -490,7 +490,13 @@ fn test_unicode() {
                 BONUS_BOUNDARY_WHITE * BONUS_FIRST_CHAR_MULTIPLIER - PENALTY_GAP_START,
             ),
         ],
-    )
+    );
+    assert_not_matches(
+        false,
+        false,
+        false,
+        &[("Flibbertigibbet / イタズラっ子たち", "lying")],
+    );
 }
 
 #[test]

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,4 +1,4 @@
-pub use nucleo_matcher::pattern::{Atom, AtomKind, CaseMatching, Pattern};
+pub use nucleo_matcher::pattern::{Atom, AtomKind, CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Matcher, Utf32String};
 
 #[cfg(test)]
@@ -46,6 +46,7 @@ impl MultiPattern {
         column: usize,
         new_text: &str,
         case_matching: CaseMatching,
+        normalization: Normalization,
         append: bool,
     ) {
         let old_status = self.cols[column].1;
@@ -61,7 +62,9 @@ impl MultiPattern {
         } else {
             self.cols[column].1 = Status::Rescore;
         }
-        self.cols[column].0.reparse(new_text, case_matching);
+        self.cols[column]
+            .0
+            .reparse(new_text, case_matching, normalization);
     }
 
     pub fn column_pattern(&self, column: usize) -> &Pattern {

--- a/src/pattern/tests.rs
+++ b/src/pattern/tests.rs
@@ -1,14 +1,14 @@
-use nucleo_matcher::pattern::CaseMatching;
+use nucleo_matcher::pattern::{CaseMatching, Normalization};
 
 use crate::pattern::{MultiPattern, Status};
 
 #[test]
 fn append() {
     let mut pat = MultiPattern::new(1);
-    pat.reparse(0, "!", CaseMatching::Smart, true);
+    pat.reparse(0, "!", CaseMatching::Smart, Normalization::Smart, true);
     assert_eq!(pat.status(), Status::Update);
-    pat.reparse(0, "!f", CaseMatching::Smart, true);
+    pat.reparse(0, "!f", CaseMatching::Smart, Normalization::Smart, true);
     assert_eq!(pat.status(), Status::Update);
-    pat.reparse(0, "!fo", CaseMatching::Smart, true);
+    pat.reparse(0, "!fo", CaseMatching::Smart, Normalization::Smart, true);
     assert_eq!(pat.status(), Status::Rescore);
 }


### PR DESCRIPTION
The real fix for #26 is to ensure that we disable normalization of the pattern has a umlaut/normalizable character. This is now handled similar to case folding. This is a breaking change. I decided to cut a 0.3.0 release for this. 
