### PR TITLE
Remove unused dev-dependency

### DIFF
--- a/matcher/Cargo.toml
+++ b/matcher/Cargo.toml
@@ -17,6 +17,3 @@ default = ["unicode-normalization", "unicode-casefold", "unicode-segmentation"]
 unicode-normalization = []
 unicode-casefold = []
 unicode-segmentation = ["dep:unicode-segmentation"]
-
-[dev-dependencies]
-cov-mark = { version = "1.1.0", default-features = true }


### PR DESCRIPTION
This PR is the same as https://github.com/helix-editor/nucleo/pull/29 but I forgot to also remove it as a `dev-dependency` back then.