### PR TITLE
add method to Atom that preserves the index of the passed list

### DIFF
--- a/matcher/src/pattern.rs
+++ b/matcher/src/pattern.rs
@@ -395,6 +395,28 @@ impl Atom {
         items.sort_by_key(|(_, score)| Reverse(*score));
         items
     }
+
+    /// Same as `match_list` expect that it returns the index in addition to the match tuple
+    pub fn match_list_with_index<T: AsRef<str>>(
+        &self,
+        items: impl IntoIterator<Item = T>,
+        matcher: &mut Matcher,
+    ) -> Vec<(T, u16, usize)> {
+        if self.needle.is_empty() {
+            return items.into_iter().map(|item| (item, 0, 0)).collect();
+        }
+        let mut buf = Vec::new();
+        let mut items: Vec<_> = items
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, item)| {
+                self.score(Utf32Str::new(item.as_ref(), &mut buf), matcher)
+                    .map(|score| (item, score, index))
+            })
+            .collect();
+        items.sort_by_key(|(_, score, _)| Reverse(*score));
+        items
+    }
 }
 
 fn pattern_atoms(pattern: &str) -> impl Iterator<Item = &str> + '_ {

--- a/matcher/src/pattern.rs
+++ b/matcher/src/pattern.rs
@@ -396,7 +396,8 @@ impl Atom {
         items
     }
 
-    /// Same as `match_list` expect that it returns the index in addition to the match tuple
+    /// Same as `match_list` expect that it returns the index appended to the tuple
+    /// Return tuple is (Match, score, index)
     pub fn match_list_with_index<T: AsRef<str>>(
         &self,
         items: impl IntoIterator<Item = T>,
@@ -499,8 +500,9 @@ impl Pattern {
         items.sort_by_key(|(_, score)| Reverse(*score));
         items
     }
-    ///
-    /// Same as `match_list` expect that it returns the index in addition to the match tuple
+
+    /// Same as `match_list` expect that it returns the index appended to the tuple
+    /// Return tuple is (Match, score, index)
     pub fn match_list_with_index<T: AsRef<str>>(
         &self,
         items: impl IntoIterator<Item = T>,

--- a/matcher/src/pattern.rs
+++ b/matcher/src/pattern.rs
@@ -499,6 +499,28 @@ impl Pattern {
         items.sort_by_key(|(_, score)| Reverse(*score));
         items
     }
+    ///
+    /// Same as `match_list` expect that it returns the index in addition to the match tuple
+    pub fn match_list_with_index<T: AsRef<str>>(
+        &self,
+        items: impl IntoIterator<Item = T>,
+        matcher: &mut Matcher,
+    ) -> Vec<(T, u32, usize)> {
+        if self.atoms.is_empty() {
+            return items.into_iter().map(|item| (item, 0, 0)).collect();
+        }
+        let mut buf = Vec::new();
+        let mut items: Vec<_> = items
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, item)| {
+                self.score(Utf32Str::new(item.as_ref(), &mut buf), matcher)
+                    .map(|score| (item, score, index))
+            })
+            .collect();
+        items.sort_by_key(|(_, score, _)| Reverse(*score));
+        items
+    }
 
     /// Matches this pattern against `haystack` (using the allocation and configuration
     /// from `matcher`) and calculates a ranking score. See the [`Matcher`].


### PR DESCRIPTION
### Why?

My use case for fuzzy string matching requires knowing the index of the thing that was matched as that index is a value on an object in a list and I want to be able to go back into that list and grab the object.
> Aside: To see exactly how I'm using this [see this PR](https://github.com/Chris4942/steam-cli/pull/1/files#diff-2bdb4466d6d72e61c6cd45aaac57f6bf52a7d7f3a79f8e36fa431d30c0f68dc6R68). The part that pertains to this is the closure referenced on the line that I'm linking to.

### What?

I added `match_list_with_index` to both `Atom` and `Pattern`. My use case relies on `Pattern`, but it seemed like the interface for `Atom` and `Pattern` are similar and so I added it to both to maintain parity between the two.

### Testing

I tested it locally in my project and it does what I'm expecting there. [See this PR](https://github.com/Chris4942/steam-cli/pull/1/files#diff-2bdb4466d6d72e61c6cd45aaac57f6bf52a7d7f3a79f8e36fa431d30c0f68dc6R68).

If you would like to see unit tests, I'm happy to write some.

### Other considerations

I considered trying to encapsulate the common logic between `match_list` and `match_list_with_index` into a common function that takes closures as arguments; however, the function is so short that that did not seem worthwhile and would likely add unneeded complexity.

I considered adding the index to the end of the tuple in the already existing function; however, I don't want to change the return type as that _could_ break projects using this package and I certainly shouldn't be introducing breaking changes as a new contributor.