### PR TITLE
Slightly change score strategy for columns

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -89,9 +89,13 @@ impl MultiPattern {
         // TODO: wheight columns?
         let mut score = 0;
         for ((pattern, _), haystack) in self.cols.iter().zip(haystack) {
-            score += pattern.score(haystack.slice(..), matcher)?
+            score += pattern.score(haystack.slice(..), matcher).unwrap_or(0);
         }
-        Some(score)
+        if score > 0 {
+            Some(score)
+        } else {
+            None
+        }
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
Previously, if a column had no match, it would short circuit returning None, stopping subsequent columns from potentially matching.

This change means that non-matching columns are scored as zero, allowing subsequent columns to be matched against.

If the match has zero score after all columns, then we return None, retaining previous behaviour.

All existing tests pass.