### PR TITLE
Fix minor documentation typos

### DIFF
--- a/matcher/src/lib.rs
+++ b/matcher/src/lib.rs
@@ -191,12 +191,13 @@ impl Matcher {
         self.fuzzy_matcher_impl::<false>(haystack, needle, &mut Vec::new())
     }
 
-    /// Find the fuzzy match with the higehest score in the `haystack` and
+    /// Find the fuzzy match with the highest score in the `haystack` and
     /// compute its indices.
     ///
     /// This functions has `O(mn)` time complexity for short inputs. To
-    /// avoid slowdowns it automatically falls back to [greedy matching]
-    /// (crate::Matcher::fuzzy_match_greedy) for large needles and haystacks
+    /// avoid slowdowns it automatically falls back to
+    /// [greedy matching](crate::Matcher::fuzzy_match_greedy) for large needles
+    /// and haystacks
     ///
     /// See the [matcher documentation](crate::Matcher) for more details.
     pub fn fuzzy_indices(

--- a/matcher/src/pattern.rs
+++ b/matcher/src/pattern.rs
@@ -419,8 +419,8 @@ pub struct Pattern {
 
 impl Pattern {
     /// Creates a pattern where each word is matched individually (whitespaces
-    /// can be escaped with `\`). Otherwise no parsing is performed (so $, !, '
-    /// and ^ don't receive special treatment). If you want to match the entire
+    /// can be escaped with `\`). Otherwise no parsing is performed (so `$`, `!`,
+    /// `'` and `^` don't receive special treatment). If you want to match the entire
     /// pattern as a single needle use a single [`Atom`] instead.
     pub fn new(
         pattern: &str,
@@ -437,7 +437,7 @@ impl Pattern {
         Pattern { atoms }
     }
     /// Creates a pattern where each word is matched individually (whitespaces
-    /// can be escaped with `\`). And $, !, ' and ^ at word boundaries will
+    /// can be escaped with `\`). And `$`, `!`, `'` and `^` at word boundaries will
     /// cause different matching behaviour (see [`AtomKind`]). These can be
     /// escaped with backslash.
     pub fn parse(pattern: &str, case_matching: CaseMatching, normalize: Normalization) -> Pattern {
@@ -479,8 +479,8 @@ impl Pattern {
     }
 
     /// Matches this pattern against `haystack` (using the allocation and configuration
-    /// from `matcher`) and calculates a ranking score. See the [`Matcher`].
-    /// Documentation for more details.
+    /// from `matcher`) and calculates a ranking score. See the [`Matcher`]
+    /// documentation for more details.
     ///
     /// *Note:*  The `ignore_case` setting is overwritten to match the casing of
     /// each pattern atom.
@@ -497,7 +497,7 @@ impl Pattern {
 
     /// Matches this pattern against `haystack` (using the allocation and
     /// configuration from `matcher`), calculates a ranking score and the match
-    /// indices. See the [`Matcher`]. Documentation for more
+    /// indices. See the [`Matcher`] documentation for more
     /// details.
     ///
     /// *Note:*  The `ignore_case` setting is overwritten to match the casing of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ impl<T> Injector<T> {
     /// # Safety
     ///
     /// Item at `index` must be initialized. That means you must have observed
-    /// `push` returning this value or `get` retunring `Some` for this value.
+    /// `push` returning this value or `get` returning `Some` for this value.
     /// Just because a later index is initialized doesn't mean that this index
     /// is initialized
     pub unsafe fn get_unchecked(&self, index: u32) -> Item<'_, T> {
@@ -204,7 +204,7 @@ impl<T: Sync + Send + 'static> Snapshot<T> {
     /// Returns `None` if the given `index` is not initialized. This function
     /// is only guarteed to return `Some` for item indices that can be found in
     /// the `matches` of this struct. Both smaller and larger indices may return
-    /// `None`
+    /// `None`.
     #[inline]
     pub fn get_item(&self, index: u32) -> Option<Item<'_, T>> {
         self.items.get(index)
@@ -288,7 +288,7 @@ impl<T: Sync + Send + 'static> Nucleo<T> {
     ///
     /// Nucleo can match items with multiple orthogonal properties. `columns`
     /// indicates how many matching columns each item (and the pattern) has. The
-    /// number of columns can not be changed after construction.
+    /// number of columns cannot be changed after construction.
     pub fn new(
         config: Config,
         notify: Arc<(dyn Fn() + Sync + Send)>,
@@ -337,8 +337,8 @@ impl<T: Sync + Send + 'static> Nucleo<T> {
     /// Restart the the item stream. Removes all items and disconnects all
     /// previously created injectors from this instance. If `clear_snapshot`
     /// is `true` then all items and matched are removed from the [`Snapshot`]
-    /// (crate::Snapshot) immediately. Otherwise the snapshot will keep the
-    /// current matches until the matcher has run again.
+    /// immediately. Otherwise the snapshot will keep the current matches until
+    /// the matcher has run again.
     ///
     /// # Note
     ///
@@ -354,6 +354,7 @@ impl<T: Sync + Send + 'static> Nucleo<T> {
         }
     }
 
+    /// Update the internal configuration.
     pub fn update_config(&mut self, config: Config) {
         self.worker.lock().update_config(config)
     }


### PR DESCRIPTION
There are a few minor typos in the documentation; this PR fixes some of the ones that I spotted.