### PR TITLE
Expose match objects from the snapshot

### DIFF
--- a/matcher/src/chars/normalize.rs
+++ b/matcher/src/chars/normalize.rs
@@ -473,7 +473,7 @@ const fn generate_table<const LEN: usize>(sparse_data: &[(char, char)]) -> [char
     let mut i = 0u32;
     let mut j = 0;
     while i < table.len() as u32 {
-        let key = unsafe { transmute(start + i) };
+        let key = unsafe { transmute::<u32, char>(start + i) };
         if sparse_data[j].0 == key {
             table[i as usize] = DATA1[j].1;
             j += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ impl<T: Sync + Send + 'static> Snapshot<T> {
         self.matches.len() as u32
     }
 
-    /// Returns an iteror over the items that correspond to a subrange of
+    /// Returns an iterator over the items that correspond to a subrange of
     /// all the matches in this snapshot.
     ///
     /// # Panics
@@ -190,7 +190,7 @@ impl<T: Sync + Send + 'static> Snapshot<T> {
     ///
     /// # Safety
     ///
-    /// Item at `index` must be initialized. That means you must have observed
+    /// Item at `index` must be initialized. That means you must have observed a
     /// match with the corresponding index in this exact snapshot. Observing
     /// a higher index is not enough as item indices can be non-contigously
     /// initialized
@@ -203,22 +203,28 @@ impl<T: Sync + Send + 'static> Snapshot<T> {
     ///
     /// Returns `None` if the given `index` is not initialized. This function
     /// is only guarteed to return `Some` for item indices that can be found in
-    /// the `matches` of this struct. Both small and larger indices may returns
+    /// the `matches` of this struct. Both smaller and larger indices may return
     /// `None`
     #[inline]
     pub fn get_item(&self, index: u32) -> Option<Item<'_, T>> {
         self.items.get(index)
     }
 
-    /// Returns a reference to the nth match.
+    /// Return the matches corresponding to this snapshot.
+    #[inline]
+    pub fn matches(&self) -> &[Match] {
+        &self.matches
+    }
+
+    /// A convenience function to return the [`Item`] corresponding to the
+    /// `n`th match.
     ///
-    /// Returns `None` if the given `index` is not initialized. This function
-    /// is only guarteed to return `Some` for item indices that can be found in
-    /// the `matches` of this struct. Both small and larger indices may returns
-    /// `None`
+    /// Returns `None` if `n` is greater than or equal to the match count.
     #[inline]
     pub fn get_matched_item(&self, n: u32) -> Option<Item<'_, T>> {
-        self.get_item(self.matches.get(n as usize)?.idx)
+        // SAFETY: A match index is guaranteed to corresponding to a valid global index in this
+        // snapshot.
+        unsafe { Some(self.get_item_unchecked(self.matches.get(n as usize)?.idx)) }
     }
 }
 


### PR DESCRIPTION
This closes #56 by exposing the internal `Match` objects within the snapshot.

As discussed, this implements the missing function: `fn matches(&self) -> &[Match]` to return the slice of matches corresponding to the `Snapshot`.

I also cleaned up two things:

- I changed the implementation of the `get_matched_item` function to internally use `get_item_unchecked`, which seems to have been the original intention.
- I tidied up the documentation to clarify that the observed indices in the `Match` objects are guaranteed to be valid for the snapshot, and that the `get_item` function will only return `None` when `n >= self.matched_item_count()`
