### PR TITLE
Properly handle windows-style newlines `\r\n`

### DIFF
--- a/matcher/src/chars.rs
+++ b/matcher/src/chars.rs
@@ -189,10 +189,14 @@ pub(crate) enum CharClass {
 pub fn graphemes(text: &str) -> impl Iterator<Item = char> + '_ {
     #[cfg(feature = "unicode-segmentation")]
     let res = text.graphemes(true).map(|grapheme| {
-        grapheme
-            .chars()
-            .next()
-            .expect("graphemes must be non-empty")
+        if grapheme == "\r\n" {
+            '\n'
+        } else {
+            grapheme
+                .chars()
+                .next()
+                .expect("graphemes must be non-empty")
+        }
     });
     #[cfg(not(feature = "unicode-segmentation"))]
     let res = text.chars();


### PR DESCRIPTION
Partially addresses #58 by checking for the presence of a carriage return `\r` and defaulting to Unicode handling in that situation.

The carriage return only check implemented here has no measurable overhead compared to the implementation on master. Some other solutions I tried out result in maybe 10% performance hit.

Technically this could result in some false positives which means more grapheme iteration. I'm not sure what the most desirable solution here is. It is unclear to me that it is worth special-casing `\r\n` handling at the cost of normal code paths.

Is it worth optimizing for ASCII only? How much better is ASCII performance, vs `Vec<char>` performance, in the matcher?



