### PR TITLE
Fix reparse trailing escape

### DIFF
--- a/matcher/src/pattern/tests.rs
+++ b/matcher/src/pattern/tests.rs
@@ -85,8 +85,38 @@ fn case_matching() {
 
 #[test]
 fn escape() {
+    // escapes only impact whitespace
     let pat = Atom::parse("foo\\ bar", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "foo bar");
+    let pat = Atom::parse("foo\\\tbar", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "foo\tbar");
+    let pat = Atom::parse("\\", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "\\");
+    let pat = Atom::parse("\\ ", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), " ");
+    let pat = Atom::parse("\\\\", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "\\\\");
+
+    // some unicode checks
+    let pat = Atom::parse("foö\\ bar", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "foö bar");
+    let pat = Atom::parse("ö\\ ", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "ö ");
+    let pat = Atom::parse("foö\\\\ bar", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "foö\\ bar");
+    let pat = Atom::parse("foo\\　bar", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "foo　bar"); // double-width IDEOGRAPHIC SPACE
+    let pat = Atom::parse("ö\\b", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "ö\\b");
+    let pat = Atom::parse("ö\\\\", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "ö\\\\");
+    let pat = Atom::parse("\\!^foö\\$", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "!^foö$");
+    assert_eq!(pat.kind, AtomKind::Fuzzy);
+    let pat = Atom::parse("!\\^foö\\$", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "^foö$");
+    assert_eq!(pat.kind, AtomKind::Substring);
+
     let pat = Atom::parse("\\!foo", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "!foo");
     assert_eq!(pat.kind, AtomKind::Fuzzy);

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -52,11 +52,19 @@ impl MultiPattern {
         let old_status = self.cols[column].1;
         if append
             && old_status != Status::Rescore
-            && self.cols[column]
-                .0
-                .atoms
-                .last()
-                .map_or(true, |last| !last.negative)
+                // must be rescored if the atom is negative or if there is an unescaped
+                // trailing `\`
+            && self.cols[column].0.atoms.last().map_or(true, |last| {
+                !last.negative
+                    && last
+                        .needle_text()
+                        .chars()
+                        .rev()
+                        .take_while(|c| *c == '\\')
+                        .count()
+                        % 2
+                        == 0
+            })
         {
             self.cols[column].1 = Status::Update;
         } else {

--- a/src/pattern/tests.rs
+++ b/src/pattern/tests.rs
@@ -11,4 +11,24 @@ fn append() {
     assert_eq!(pat.status(), Status::Update);
     pat.reparse(0, "!fo", CaseMatching::Smart, Normalization::Smart, true);
     assert_eq!(pat.status(), Status::Rescore);
+
+    let mut pat = MultiPattern::new(1);
+    pat.reparse(0, "a\\\\", CaseMatching::Smart, Normalization::Smart, true);
+    assert_eq!(pat.status(), Status::Update);
+    pat.reparse(
+        0,
+        "a\\\\\\",
+        CaseMatching::Smart,
+        Normalization::Smart,
+        true,
+    );
+    assert_eq!(pat.status(), Status::Update);
+    pat.reparse(
+        0,
+        "a\\\\\\\\",
+        CaseMatching::Smart,
+        Normalization::Smart,
+        true,
+    );
+    assert_eq!(pat.status(), Status::Rescore);
 }


### PR DESCRIPTION
Two changes here:

First, fixes #66 to check for a trailing unescaped `\`.

The other fix, which is in the second commit and which I am slightly less sure about, is to replace an ASCII whitespace check with a `is_whitespace` check in `Atom::new`. This behaviour was previously changed in #65 for `Pattern::(re)parse`, is it also correct for this to take place in` Atom::new`? If this is incorrect I'll drop the second commit.