### PR TITLE
Fix failed compilation with `--no-default-features`

### DIFF
--- a/matcher/src/pattern.rs
+++ b/matcher/src/pattern.rs
@@ -14,6 +14,7 @@ use crate::Utf32String;
 /// How to treat a case mismatch between two characters.
 pub enum CaseMatching {
     /// Characters never match their case folded version (`a != A`).
+    #[cfg_attr(not(feature = "unicode-casefold"), default)]
     Respect,
     /// Characters always match their case folded version (`a == A`).
     #[cfg(feature = "unicode-casefold")]
@@ -30,6 +31,7 @@ pub enum CaseMatching {
 /// How to handle unicode normalization,
 pub enum Normalization {
     /// Characters never match their normalized version (`a != ä`).
+    #[cfg_attr(not(feature = "unicode-normalization"), default)]
     Never,
     /// Acts like [`Never`](Normalization::Never) if any character in a pattern atom
     /// would need to be normalized. Otherwise normalization occurs (`a == ä` but `ä != a`).


### PR DESCRIPTION
Currently `nucleo_matcher` does not compile with `--no-default-features` because the default values for some enums do not exist with `--no-default-features`. It is quite surprising to me that this has not been caught before!

I couldn't figure out how to make attribute macros work with conditional compilation so I just wrote out the implementations manually.

It seems that this is not caught in CI because of a cargo bug (maybe https://github.com/rust-lang/cargo/issues/7160 ?) so I guess CI should be fixed too. I don't want to touch the CI file myself though. I had to run
```
cargo check --package nucleo-matcher --no-default-features
```
to get the error message. Maybe there is a better way to do this.