### PR TITLE
Fix case-sensitive prefix matching

### DIFF
--- a/matcher/src/lib.rs
+++ b/matcher/src/lib.rs
@@ -727,7 +727,7 @@ impl Matcher {
                             .iter()
                             .map(|c| c.normalize(&self.config)))
                 } else {
-                    haystack == needle
+                    &haystack[start..end] == needle
                 };
                 if !matched {
                     return None;

--- a/matcher/src/tests.rs
+++ b/matcher/src/tests.rs
@@ -387,6 +387,38 @@ fn test_substring() {
 }
 
 #[test]
+fn test_substring_case_sensitive() {
+    assert_matches(
+        &[Substring, Prefix],
+        false,
+        true,
+        false,
+        false,
+        &[
+            (
+                "Foo bar baz",
+                "Foo",
+                &[0, 1, 2],
+                BONUS_BOUNDARY_WHITE * (BONUS_FIRST_CHAR_MULTIPLIER + 2),
+            ),
+            (
+                "Fȫô bar baz",
+                "Fȫô",
+                &[0, 1, 2],
+                BONUS_BOUNDARY_WHITE * (BONUS_FIRST_CHAR_MULTIPLIER + 2),
+            ),
+            (
+                "Foo ฿ar baz",
+                "Foo",
+                &[0, 1, 2],
+                BONUS_BOUNDARY_WHITE * (BONUS_FIRST_CHAR_MULTIPLIER + 2),
+            ),
+        ],
+    );
+    assert_not_matches_with(false, true, &[Substring, Prefix], &[("foo bar baz", "Foo")]);
+}
+
+#[test]
 fn test_fuzzy_case_sensitive() {
     assert_matches(
         &[FuzzyGreedy, FuzzyOptimal],


### PR DESCRIPTION
Currently, it looks like when trying to case-sensitively prefix match a string, Nucleo instead does an exact match. This PR makes it so that the needle is only compared to the relevant prefix of the haystack.

I added one test, with one test case for each of the three code paths (ASCII haystack + ASCII needle, Unicode haystack + Unicode needle, Unicode haystack + ASCII needle).