### PR TITLE
fix(boxcar): pre-allocation of buckets now checks position inside the current bucket

### DIFF
--- a/src/boxcar.rs
+++ b/src/boxcar.rs
@@ -144,7 +144,7 @@ impl<T> Vec<T> {
         let location = Location::of(index);
 
         // eagerly allocate the next bucket if we are close to the end of this one
-        if index == (location.bucket_len - (location.bucket_len >> 3)) {
+        if location.entry == (location.bucket_len - (location.bucket_len >> 3)) {
             if let Some(next_bucket) = self.buckets.get(location.bucket as usize + 1) {
                 Vec::get_or_alloc(next_bucket, location.bucket_len << 1, self.columns);
             }


### PR DESCRIPTION
From my understanding, this code's intent is to eagerly allocate the next bucket if we're about to write the first entry of the last 1/8th of the current bucket.
```
                       7/8             1/8  
         <---------------------------><---->
...--]  [========== current bucket =========]  [-------------------------- next bucket...
                                      ↑
                          first entry of the last 1/8th
                          of the current bucket
```

The code currently checks if:
```rust
if index == (location.bucket_len - (location.bucket_len >> 3)) {...}
```
Where `index` is - *if I'm not mistaken* a global vector index and should really be `location.entry` instead which corresponds to the relative location inside the current bucket:
```rust
if location.entry == (location.bucket_len - (location.bucket_len >> 3)) {...}
```