### PR TITLE
docs: add return type explanation for score method

### DIFF
--- a/matcher/src/pattern.rs
+++ b/matcher/src/pattern.rs
@@ -302,7 +302,7 @@ impl Atom {
     /// *Note:*  The `ignore_case` setting is overwritten to match the casing of
     /// each pattern atom.
     ///
-    /// Returns [None] if `needle` from `matcher` is longer than `haystack`
+    /// Returns `None` if `needle` from `matcher` is longer than `haystack`
     pub fn score(&self, haystack: Utf32Str<'_>, matcher: &mut Matcher) -> Option<u16> {
         matcher.config.ignore_case = self.ignore_case;
         matcher.config.normalize = self.normalize;


### PR DESCRIPTION
This PR improves the documentation for the [pattern::source method](https://github.com/helix-editor/nucleo/blob/dc3054066d4e6e2f7e210723086f3a9d6fbd3989/matcher/src/pattern.rs#L304C1-L304C88) by providing additional context for the return type.

The docstring now specifies, in which Cases None will be returned, as this is unintuitive otherwise. 

If a rewording is wanted, please let me know.