### PR TITLE
Pattern parsing fixes related to escape handling

### DIFF
--- a/matcher/src/pattern/tests.rs
+++ b/matcher/src/pattern/tests.rs
@@ -85,8 +85,38 @@ fn case_matching() {
 
 #[test]
 fn escape() {
+    // escapes only impact whitespace
     let pat = Atom::parse("foo\\ bar", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "foo bar");
+    let pat = Atom::parse("foo\\\tbar", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "foo\tbar");
+    let pat = Atom::parse("\\", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "\\");
+    let pat = Atom::parse("\\ ", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), " ");
+    let pat = Atom::parse("\\\\", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "\\\\");
+
+    // some unicode checks
+    let pat = Atom::parse("foö\\ bar", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "foö bar");
+    let pat = Atom::parse("ö\\ ", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "ö ");
+    let pat = Atom::parse("foö\\\\ bar", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "foö\\ bar");
+    let pat = Atom::parse("foo\\　bar", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "foo　bar"); // double-width IDEOGRAPHIC SPACE
+    let pat = Atom::parse("ö\\b", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "ö\\b");
+    let pat = Atom::parse("ö\\\\", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "ö\\\\");
+    let pat = Atom::parse("\\!^foö\\$", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "!^foö$");
+    assert_eq!(pat.kind, AtomKind::Fuzzy);
+    let pat = Atom::parse("!\\^foö\\$", CaseMatching::Smart, Normalization::Smart);
+    assert_eq!(pat.needle.to_string(), "^foö$");
+    assert_eq!(pat.kind, AtomKind::Substring);
+
     let pat = Atom::parse("\\!foo", CaseMatching::Smart, Normalization::Smart);
     assert_eq!(pat.needle.to_string(), "!foo");
     assert_eq!(pat.kind, AtomKind::Fuzzy);

--- a/matcher/src/score.rs
+++ b/matcher/src/score.rs
@@ -67,7 +67,7 @@ impl Config {
         } else if class == CharClass::Whitespace {
             self.bonus_boundary_white
         } else if class == CharClass::NonWord {
-            return BONUS_NON_WORD;
+            BONUS_NON_WORD
         } else {
             0
         }

--- a/matcher/src/utf32_str.rs
+++ b/matcher/src/utf32_str.rs
@@ -335,7 +335,7 @@ impl Utf32String {
     /// Creates a slice with a string that contains the characters in
     /// the specified **character range**.
     #[inline]
-    pub fn slice(&self, range: impl RangeBounds<usize>) -> Utf32Str {
+    pub fn slice(&self, range: impl RangeBounds<usize>) -> Utf32Str<'_> {
         let start = match range.start_bound() {
             Bound::Included(&start) => start,
             Bound::Excluded(&start) => start + 1,
@@ -355,7 +355,7 @@ impl Utf32String {
     /// Same as `slice` but accepts a u32 range for convenience since
     /// those are the indices returned by the matcher.
     #[inline]
-    pub fn slice_u32(&self, range: impl RangeBounds<u32>) -> Utf32Str {
+    pub fn slice_u32(&self, range: impl RangeBounds<u32>) -> Utf32Str<'_> {
         let start = match range.start_bound() {
             Bound::Included(&start) => start,
             Bound::Excluded(&start) => start + 1,

--- a/src/boxcar.rs
+++ b/src/boxcar.rs
@@ -777,6 +777,7 @@ mod tests {
 
     // test |values| does not fit in the boxcar
     #[test]
+    #[allow(clippy::manual_repeat_n)]
     fn extend_over_max_capacity() {
         let vec = Vec::<u32>::with_capacity(1, 1);
         let count = MAX_ENTRIES as usize + 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,10 +84,10 @@ impl<T> Injector<T> {
     ///
     /// You should favor this function over `push` if at least one of the following is true:
     /// - the number of items you're adding can be computed beforehand and is typically larger
-    ///     than 1k
+    ///   than 1k
     /// - you're able to batch incoming items
     /// - you're adding items from multiple threads concurrently (this function results in less
-    ///     contention)
+    ///   contention)
     pub fn extend<I>(&self, values: I, fill_columns: impl Fn(&T, &mut [Utf32String]))
     where
         I: IntoIterator<Item = T> + ExactSizeIterator,

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -41,6 +41,7 @@ impl MultiPattern {
     /// to the previous `reparse` invocation is a prefix of `new_text`. This enables
     /// additional optimizations but can lead to missing matches if an incorrect value
     /// is passed.
+    #[allow(clippy::unnecessary_map_or)]
     pub fn reparse(
         &mut self,
         column: usize,
@@ -54,13 +55,12 @@ impl MultiPattern {
             && old_status != Status::Rescore
                 // must be rescored if the atom is negative or if there is a
                 // trailing `\`
-            && self.cols[column].0.atoms.last().is_none_or(|last| {
+            && self.cols[column].0.atoms.last().map_or(true, |last| {
                 !last.negative
                     && last
                         .needle_text()
                         .chars()
-                        .next_back()
-                        .is_none_or(|c| c != '\\')
+                        .next_back() != Some('\\')
             })
         {
             self.cols[column].1 = Status::Update;

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -52,11 +52,16 @@ impl MultiPattern {
         let old_status = self.cols[column].1;
         if append
             && old_status != Status::Rescore
-            && self.cols[column]
-                .0
-                .atoms
-                .last()
-                .map_or(true, |last| !last.negative)
+                // must be rescored if the atom is negative or if there is a
+                // trailing `\`
+            && self.cols[column].0.atoms.last().is_none_or(|last| {
+                !last.negative
+                    && last
+                        .needle_text()
+                        .chars()
+                        .next_back()
+                        .is_none_or(|c| c != '\\')
+            })
         {
             self.cols[column].1 = Status::Update;
         } else {

--- a/src/pattern/tests.rs
+++ b/src/pattern/tests.rs
@@ -11,4 +11,16 @@ fn append() {
     assert_eq!(pat.status(), Status::Update);
     pat.reparse(0, "!fo", CaseMatching::Smart, Normalization::Smart, true);
     assert_eq!(pat.status(), Status::Rescore);
+
+    let mut pat = MultiPattern::new(1);
+    pat.reparse(0, "a\\\\", CaseMatching::Smart, Normalization::Smart, true);
+    assert_eq!(pat.status(), Status::Update);
+    pat.reparse(
+        0,
+        "a\\\\\\\\",
+        CaseMatching::Smart,
+        Normalization::Smart,
+        true,
+    );
+    assert_eq!(pat.status(), Status::Rescore);
 }


### PR DESCRIPTION
This PR implements three parsing fixes.

1. Fixes #66: we now check for a trailing backslash `\` when running 'reparse' to correctly force a complete rescore (rather than just an update).
2. Updates the ASCII parsing code to use the ASCII `is_whitespace` checks (same behaviour as with the Unicode handling).
3. Fixes a bug in Unicode parsing code, where there was a `\` push that had to be deferred until the beginning of the subsequent loop. This was causing invalid handling of e.g. `foö\ bar`.

I've also added quite a few tests to check that the parsing code behaves as expected.

This was previously #67 but now slightly better implementation and I'm making a new PR because the other one is filled with unnecessary details.