### PR TITLE
Slightly better panic message when non-match is not caught by prefilter

### DIFF
--- a/matcher/src/fuzzy_optimal.rs
+++ b/matcher/src/fuzzy_optimal.rs
@@ -36,7 +36,7 @@ impl Matcher {
         if !matched {
             assert!(
                 !N::ASCII || !H::ASCII,
-                "should have been caught by prefilter"
+                "Non-match should have been caught by prefilter. Maybe `needle` is not normalized?"
             );
             return None;
         }


### PR DESCRIPTION
Resolves #83 

This changes the panic message from `should have been caught by prefilter` to
```
Non-match should have been caught by prefilter. Maybe `needle` is not normalized?
```
which is hopefully clearer.