### PR TITLE
Fix the trait bounds on `Injector::extend`

### DIFF
--- a/src/boxcar.rs
+++ b/src/boxcar.rs
@@ -186,15 +186,17 @@ impl<T> Vec<T> {
     /// Extends the vector by appending multiple elements at once.
     pub fn extend<I>(&self, values: I, fill_columns: impl Fn(&T, &mut [Utf32String]))
     where
-        I: IntoIterator<Item = T> + ExactSizeIterator,
+        I: IntoIterator<Item = T>,
+        <I as IntoIterator>::IntoIter: ExactSizeIterator,
     {
+        let mut values = values.into_iter();
         let count: u32 = values
             .len()
             .try_into()
             .expect("overflowed maximum capacity");
         if count == 0 {
             assert!(
-                values.into_iter().next().is_none(),
+                values.next().is_none(),
                 "The `values` variable reported incorrect length."
             );
             return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,8 @@ impl<T> Injector<T> {
     ///     contention)
     pub fn extend<I>(&self, values: I, fill_columns: impl Fn(&T, &mut [Utf32String]))
     where
-        I: IntoIterator<Item = T> + ExactSizeIterator,
+        I: IntoIterator<Item = T>,
+        <I as IntoIterator>::IntoIter: ExactSizeIterator,
     {
         self.items.extend(values, fill_columns);
         (self.notify)();


### PR DESCRIPTION
This PR fixes the trait bounds on `Injector::extend` and `boxcar::Vec` from #74 

The previous trait bounds were `IntoIterator + ExactSizeIterator` but `ExactSizeIterator` implies `Iterator` implies `IntoIterator` so these bounds are redundant.

The bounds have been updated to check that the associated `IntoIter` type is an `ExactSizeIterator` instead.