### PR TITLE
chore: Make Clippy happy to unblock the CI

### DIFF
--- a/matcher/src/score.rs
+++ b/matcher/src/score.rs
@@ -67,7 +67,7 @@ impl Config {
         } else if class == CharClass::Whitespace {
             self.bonus_boundary_white
         } else if class == CharClass::NonWord {
-            return BONUS_NON_WORD;
+            BONUS_NON_WORD
         } else {
             0
         }

--- a/matcher/src/utf32_str.rs
+++ b/matcher/src/utf32_str.rs
@@ -335,7 +335,7 @@ impl Utf32String {
     /// Creates a slice with a string that contains the characters in
     /// the specified **character range**.
     #[inline]
-    pub fn slice(&self, range: impl RangeBounds<usize>) -> Utf32Str {
+    pub fn slice(&self, range: impl RangeBounds<usize>) -> Utf32Str<'_> {
         let start = match range.start_bound() {
             Bound::Included(&start) => start,
             Bound::Excluded(&start) => start + 1,
@@ -355,7 +355,7 @@ impl Utf32String {
     /// Same as `slice` but accepts a u32 range for convenience since
     /// those are the indices returned by the matcher.
     #[inline]
-    pub fn slice_u32(&self, range: impl RangeBounds<u32>) -> Utf32Str {
+    pub fn slice_u32(&self, range: impl RangeBounds<u32>) -> Utf32Str<'_> {
         let start = match range.start_bound() {
             Bound::Included(&start) => start,
             Bound::Excluded(&start) => start + 1,

--- a/src/boxcar.rs
+++ b/src/boxcar.rs
@@ -780,7 +780,7 @@ mod tests {
     fn extend_over_max_capacity() {
         let vec = Vec::<u32>::with_capacity(1, 1);
         let count = MAX_ENTRIES as usize + 2;
-        let iter = std::iter::repeat(0).take(count);
+        let iter = std::iter::repeat_n(0, count);
         assert!(std::panic::catch_unwind(|| vec.extend(iter, |_, _| {})).is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub struct Item<'a, T> {
 /// and sent across threads.
 pub struct Injector<T> {
     items: Arc<boxcar::Vec<T>>,
-    notify: Arc<(dyn Fn() + Sync + Send)>,
+    notify: Arc<dyn Fn() + Sync + Send>,
 }
 
 impl<T> Clone for Injector<T> {
@@ -84,10 +84,10 @@ impl<T> Injector<T> {
     ///
     /// You should favor this function over `push` if at least one of the following is true:
     /// - the number of items you're adding can be computed beforehand and is typically larger
-    ///     than 1k
+    ///   than 1k
     /// - you're able to batch incoming items
     /// - you're adding items from multiple threads concurrently (this function results in less
-    ///     contention)
+    ///   contention)
     pub fn extend<I>(&self, values: I, fill_columns: impl Fn(&T, &mut [Utf32String]))
     where
         I: IntoIterator<Item = T> + ExactSizeIterator,
@@ -283,7 +283,7 @@ pub struct Nucleo<T: Sync + Send + 'static> {
     pool: ThreadPool,
     state: State,
     items: Arc<boxcar::Vec<T>>,
-    notify: Arc<(dyn Fn() + Sync + Send)>,
+    notify: Arc<dyn Fn() + Sync + Send>,
     snapshot: Snapshot<T>,
     /// The pattern matched by this matcher. To update the match pattern
     /// [`MultiPattern::reparse`](`pattern::MultiPattern::reparse`) should be used.
@@ -308,7 +308,7 @@ impl<T: Sync + Send + 'static> Nucleo<T> {
     /// number of columns cannot be changed after construction.
     pub fn new(
         config: Config,
-        notify: Arc<(dyn Fn() + Sync + Send)>,
+        notify: Arc<dyn Fn() + Sync + Send>,
         num_threads: Option<usize>,
         columns: u32,
     ) -> Self {

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -50,6 +50,10 @@ impl MultiPattern {
         append: bool,
     ) {
         let old_status = self.cols[column].1;
+
+        // The `map_or` can be replaced by `is_none_or` but it's not part of
+        // Rust 1.65, which the minimum supported Rust version.
+        #[allow(clippy::unnecessary_map_or)]
         if append
             && old_status != Status::Rescore
             && self.cols[column]

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -35,7 +35,7 @@ pub(crate) struct Worker<T: Sync + Send + 'static> {
     pub(crate) should_notify: Arc<AtomicBool>,
     pub(crate) was_canceled: bool,
     pub(crate) last_snapshot: u32,
-    notify: Arc<(dyn Fn() + Sync + Send)>,
+    notify: Arc<dyn Fn() + Sync + Send>,
     pub(crate) items: Arc<boxcar::Vec<T>>,
     in_flight: Vec<u32>,
 }
@@ -59,7 +59,7 @@ impl<T: Sync + Send + 'static> Worker<T> {
     pub(crate) fn new(
         worker_threads: Option<usize>,
         config: Config,
-        notify: Arc<(dyn Fn() + Sync + Send)>,
+        notify: Arc<dyn Fn() + Sync + Send>,
         cols: u32,
     ) -> (ThreadPool, Self) {
         let worker_threads = worker_threads


### PR DESCRIPTION
This patch makes Clippy happy so that the CI job _Lints_ can run again.